### PR TITLE
Adjust type casters priorities with space between

### DIFF
--- a/src/TypeCaster/ArrayTypeCaster.php
+++ b/src/TypeCaster/ArrayTypeCaster.php
@@ -35,6 +35,6 @@ final class ArrayTypeCaster implements TypeCasterInterface
 
     public function getPriority(): int
     {
-        return 3; // before ObjectTypeCaster
+        return 5; // before ObjectTypeCaster
     }
 }

--- a/src/TypeCaster/ObjectTypeCaster.php
+++ b/src/TypeCaster/ObjectTypeCaster.php
@@ -58,7 +58,7 @@ final class ObjectTypeCaster implements TypeCasterInterface
 
     public function getPriority(): int
     {
-        return 2;
+        return 3;
     }
 
     /**


### PR DESCRIPTION
Increase priorities to keep unoccupied numbers and be able to override default type casters